### PR TITLE
Exception: Show list of bad keys if exist.

### DIFF
--- a/src/Exceptions/AbstractException.php
+++ b/src/Exceptions/AbstractException.php
@@ -54,9 +54,9 @@ abstract class AbstractException extends RuntimeException implements ExceptionIn
         if ($message === null) {
             $message = Response::$statusCodesErrors[$statusCode] ?? 'Operace neproběhla v pořádku.';
         }
-		if (isset($response[0]) === true && \is_array($response[0]) === true && \count($response[0]) > 0) {
-			$message .= "\n" . 'Please check keys: "' . implode('", "', array_keys($response[0])) . '".';
-		}
+        if (isset($response[0]) === true && \is_array($response[0]) === true && \count($response[0]) > 0) {
+            $message .= "\n" . 'Please check keys: "' . implode('", "', array_keys($response[0])) . '".';
+        }
 
         // construct exception
         parent::__construct($message, $statusCode, $previous);

--- a/src/Exceptions/AbstractException.php
+++ b/src/Exceptions/AbstractException.php
@@ -54,6 +54,9 @@ abstract class AbstractException extends RuntimeException implements ExceptionIn
         if ($message === null) {
             $message = Response::$statusCodesErrors[$statusCode] ?? 'Operace neproběhla v pořádku.';
         }
+		if (isset($response[0]) === true && \is_array($response[0]) === true && \count($response[0]) > 0) {
+			$message .= "\n" . 'Please check keys: "' . implode('", "', array_keys($response[0])) . '".';
+		}
 
         // construct exception
         parent::__construct($message, $statusCode, $previous);


### PR DESCRIPTION
## Description

Very often a too generic error is displayed, even though in response we can find out which keys are missing or wrong.

Original behavior:

![Snímek obrazovky 2021-01-31 v 11 19 20](https://user-images.githubusercontent.com/4738758/106380993-2b80ef80-63b6-11eb-9577-96373644e3cf.png)

New behavior:

![Snímek obrazovky 2021-01-31 v 11 19 34](https://user-images.githubusercontent.com/4738758/106380998-33d92a80-63b6-11eb-9569-be60665c3507.png)

Thanks.